### PR TITLE
Better headers support

### DIFF
--- a/Sendwithus/API/Email.cs
+++ b/Sendwithus/API/Email.cs
@@ -18,8 +18,8 @@ namespace Sendwithus
         public Collection<EmailRecipient> bcc { get; set; }
         public EmailSender sender { get; set; }
         public Collection<string> tags { get; set; }
-        public Dictionary<string, string> headers { get; set; }  // TODO: Confirm that this is the right representation for headers (looks like it is from the python library's usage)
-        public EmailFileData inline { get; set; }   // TODO: is this the right representation of inline?  Should it be a list of EmailFileData? Are other fields possibe beyond ID and Data?
+        public Dictionary<string, object> headers { get; set; }
+        public EmailFileData inline { get; set; }
         public Collection<EmailFileData> files { get; set; }
         public string esp_account { get; set; }
         public string locale { get; set; }
@@ -39,7 +39,7 @@ namespace Sendwithus
             cc = new Collection<EmailRecipient>();
             bcc = new Collection<EmailRecipient>();
             tags = new Collection<string>();
-            headers = new Dictionary<string, string>();
+            headers = new Dictionary<string, object>();
             inline = new EmailFileData();   // TODO: is this the right representation of inline?  Should it be a list of EmailFileData? Are other fields possibe beyond ID and Data?
             files = new Collection<EmailFileData>();
         }

--- a/Sendwithus/API/Email.cs
+++ b/Sendwithus/API/Email.cs
@@ -40,7 +40,7 @@ namespace Sendwithus
             bcc = new Collection<EmailRecipient>();
             tags = new Collection<string>();
             headers = new Dictionary<string, object>();
-            inline = new EmailFileData();   // TODO: is this the right representation of inline?  Should it be a list of EmailFileData? Are other fields possibe beyond ID and Data?
+            inline = new EmailFileData();
             files = new Collection<EmailFileData>();
         }
 

--- a/Sendwithus/SendwithusTest/Tests/EmailTest.cs
+++ b/Sendwithus/SendwithusTest/Tests/EmailTest.cs
@@ -32,6 +32,7 @@ namespace SendwithusTest
         private const string DEFAULT_TAG_3 = "tag3";
         private const string DEFAULT_HEADER_NAME = "X-HEADER-ONE";
         private const string DEFAULT_HEADER_VALUE = "header-value";
+        private const string DEFAULT_COMPLEX_HEADER_NAME = "options";
         private const string DEFAULT_INLINE_ID = "pixel.gif";
         private const string DEFAULT_INLINE_DATA = "R0lGODdhAQABAPAAAH//ACZFySH5BAEAAAEALAAAAAABAAEAAAICRAEAOw==";
         private const string DEFAULT_FILE_NAME_1 = "doct.txt";
@@ -164,6 +165,9 @@ namespace SendwithusTest
             email.tags.Add(DEFAULT_TAG_2);
             email.tags.Add(DEFAULT_TAG_3);
             email.headers.Add(DEFAULT_HEADER_NAME, DEFAULT_HEADER_VALUE);
+            var complex_header = new Dictionary<string, bool>();
+            complex_header.Add("transactional", true);
+            email.headers.Add(DEFAULT_COMPLEX_HEADER_NAME, complex_header);
             email.inline.id = DEFAULT_INLINE_ID;
             email.inline.data = DEFAULT_INLINE_DATA;
             email.files.Add(new EmailFileData(DEFAULT_FILE_NAME_1, DEFAULT_FILE_DATA));

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@
 #---------------------------------#
 
 # version format
-version: 2.0.{build}
+version: 2.1.{build}
 
 # you can use {branch} name in version format too
 # version: 1.0.{build}-{branch}


### PR DESCRIPTION
## Description
The `headers` field on the Email object is now a more generic `Dictionary<string, object>` rather than a `Dictionary<string, string>`.

## Motivation and Context
The `headers` field accepts some optional parameters that will be passed to the email service provider by Sendwithus. These parameters can be objects and not simple key, value pairs which this client used to enforce.  This also addresses issue #15 

## How Has This Been Tested?
Tests have been updated to reflect the changes. This has also been manually tested against Sendwithus' API.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
