### PR TITLE
Change template data type from dictionary to object for send and render

### DIFF
--- a/Sendwithus/API/Email.cs
+++ b/Sendwithus/API/Email.cs
@@ -12,7 +12,7 @@ namespace Sendwithus
     public class Email
     {
         public string template { get; set; } // The template ID
-        public Dictionary<string, object> template_data { get; set; }
+        public object template_data { get; set; }
         public EmailRecipient recipient { get; set; }
         public Collection<EmailRecipient> cc { get; set; }
         public Collection<EmailRecipient> bcc { get; set; }
@@ -30,7 +30,7 @@ namespace Sendwithus
         /// </summary>
         /// <param name="template">The template ID to send</param>
         /// <param name="templateData">Object containing email template data</param>
-        public Email(string template, Dictionary<string, object> templateData, EmailRecipient recipient)
+        public Email(string template, object templateData, EmailRecipient recipient)
         {
             this.template = template;
             this.template_data = templateData;
@@ -42,6 +42,17 @@ namespace Sendwithus
             headers = new Dictionary<string, object>();
             inline = new EmailFileData();
             files = new Collection<EmailFileData>();
+        }
+
+        /// <summary>
+        /// Constructor for an email
+        /// </summary>
+        /// <param name="template">The template ID to send</param>
+        /// <param name="templateData">Object containing email template data</param>
+        public Email(string template, Dictionary<string, object> templateData, EmailRecipient recipient)
+            : this(template, (object)templateData, recipient)
+        {
+
         }
 
         /// <summary>

--- a/Sendwithus/API/Render.cs
+++ b/Sendwithus/API/Render.cs
@@ -13,7 +13,7 @@ namespace Sendwithus
     public class Render
     {
         public string template { get; set; }
-        public Dictionary<string, object> template_data  { get; set; }
+        public object template_data  { get; set; }
         public string version_id { get; set; }
         public string version_name { get; set; }
         public string locale { get; set; }
@@ -24,7 +24,7 @@ namespace Sendwithus
         /// </summary>
         /// <param name="templateId">The ID of the template</param>
         /// <param name="templateData">The template data</param>
-        public Render(string templateId, Dictionary<string, object> templateData)
+        public Render(string templateId, object templateData)
         {
             this.template = templateId;
             this.template_data = templateData;
@@ -33,6 +33,15 @@ namespace Sendwithus
             locale = String.Empty;
             strict = false;
         }
+
+        /// <summary>
+        /// Constructor for render data with a dictionary of template values
+        /// </summary>
+        /// <param name="templateId">The ID of the template</param>
+        /// <param name="templateData">The template data</param>
+        public Render(string templateId, Dictionary<string, object> templateData)
+            : this(templateId, (object)templateData)
+        { }
 
         /// <summary>
         /// Render a Template with data.

--- a/Sendwithus/SendwithusTest/Tests/EmailTest.cs
+++ b/Sendwithus/SendwithusTest/Tests/EmailTest.cs
@@ -98,6 +98,29 @@ namespace SendwithusTest
         }
 
         /// <summary>
+        /// Tests the API call POST /send with an object's properties to serialize as the template data instead of a dictionary.
+        /// </summary>
+        /// <returns>The asynchronous task</returns>
+        [Test]
+        public async Task TestSendEmailWithObjectPropertiesAsync()
+        {
+            Trace.WriteLine("POST /send");
+
+            // Construct and send an email with all of the optional data
+            try
+            {
+                var response = await BuildAndSendEmailWithObjectTemplateDataAsync();
+
+                // Validate the response
+                SendwithusClientTest.ValidateResponse(response);
+            }
+            catch (AggregateException exception)
+            {
+                Assert.Fail(exception.ToString());
+            }
+        }
+
+        /// <summary>
         /// Tests the POST /send API call with an invalid template ID
         /// </summary>
         /// <returns>The asynchronous task</returns>
@@ -146,13 +169,14 @@ namespace SendwithusTest
         {
             var email = BuildBarebonesEmail();
 
-            email.template_data.Add("first_name", "Chuck");
-            email.template_data.Add("last_name", "Norris");
-            email.template_data.Add("img", "http://placekitten.com/50/60");
+            var templateDataDictionary = email.template_data as Dictionary<string, object>;
+            templateDataDictionary.Add("first_name", "Chuck");
+            templateDataDictionary.Add("last_name", "Norris");
+            templateDataDictionary.Add("img", "http://placekitten.com/50/60");
             var link = new Dictionary<string, string>();
             link.Add("url", "https://www.sendwithus.com");
             link.Add("text", "sendwithus!");
-            email.template_data.Add("link", link);
+            templateDataDictionary.Add("link", link);
             email.recipient.name = DEFAULT_EMAIL_NAME;
             email.cc.Add(new EmailRecipient(DEFAULT_CC_EMAIL_ADDRESS_1, DEFAULT_EMAIL_NAME));
             email.cc.Add(new EmailRecipient(DEFAULT_CC_EMAIL_ADDRESS_2, DEFAULT_EMAIL_NAME));
@@ -176,6 +200,30 @@ namespace SendwithusTest
             email.locale = DEFAULT_LOCALE;
             email.esp_account = DEFAULT_ESP_ACCOUNT;
 
+            // Make the API call
+            return await email.Send();
+        }
+
+        /// <summary>
+        /// Build and send an email with all of the parameters included
+        /// Public so that it can also be used by the BatchApiRequestTest library
+        /// </summary>
+        /// <returns>The API response to the Email Send call</returns>
+        public static async Task<EmailResponse> BuildAndSendEmailWithObjectTemplateDataAsync()
+        {
+            var email = BuildBarebonesEmail();
+            email.template_data = new
+            {
+                first_name = "Chuck",
+                last_name = "Norris",
+                img = "http://placekitten.com/50/60",
+                link = new
+                {
+                    url = "https://www.sendwithus.com",
+                    text = "sendwithus!"
+                }
+            };
+            
             // Make the API call
             return await email.Send();
         }

--- a/Sendwithus/SendwithusTest/Tests/RenderTest.cs
+++ b/Sendwithus/SendwithusTest/Tests/RenderTest.cs
@@ -102,6 +102,29 @@ namespace SendwithusTest
         }
 
         /// <summary>
+        /// Tests the API call POST /render with an object's properties to serialize as the template data instead of a dictionary.
+        /// </summary>
+        /// <returns>The asynchronous task</returns>
+        [Test]
+        public async Task TestRenderTemplateWithObjectPropertiesAsync()
+        {
+            Trace.WriteLine("POST /render");
+
+            // Make the API call
+            try
+            {
+                var renderTemplateResponse = await BuildAndSendRenderTemplateRequestWithObjectTemplateData();
+
+                // Validate the response
+                SendwithusClientTest.ValidateResponse(renderTemplateResponse);
+            }
+            catch (AggregateException exception)
+            {
+                Assert.Fail(exception.ToString());
+            }
+        }
+
+        /// <summary>
         /// Tests the API call POST /render with an invalid template ID
         /// </summary>
         /// <returns>The asynchronous task</returns>
@@ -155,6 +178,21 @@ namespace SendwithusTest
             var renderTemplate = new Render(DEFAULT_TEMPLATE_ID, templateData);
             renderTemplate.version_name = DEFAULT_VERSION_NAME;
             renderTemplate.locale = DEFAULT_LOCALE;
+            renderTemplate.strict = true;
+            return await renderTemplate.RenderTemplateAsync();
+        }
+
+        /// <summary>
+        /// Builds and sends a RenderTemplate request with an anonymous object as the template data instead of a dictionary.
+        /// </summary>
+        /// <returns>A response containing the status of API call and the newly rendered template</returns>
+        private static async Task<RenderTemplateResponse> BuildAndSendRenderTemplateRequestWithObjectTemplateData()
+        {
+            var templateData = new
+            {
+                amount = "$12.00"
+            };
+            var renderTemplate = new Render(DEFAULT_TEMPLATE_ID, templateData);
             renderTemplate.strict = true;
             return await renderTemplate.RenderTemplateAsync();
         }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
As discussed in issue #13, this change makes the interface for sending and rendering messages accept an arbitrary object for serialization instead of only a `Dictionary<string, object>`.

Template data is passed into serialization and an arbitrary serializable object will still produce JSON that the API will accept.

## Motivation and Context
Taking existing models and objects and translating them into Dictionaries by string for property name can be a bit of a pain. This change simply extends the existing functionality to add another means of expressing the template data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
All existing unit tests were executed and new unit test cases were added that invoke the same test data but provided in anonymous-typed objects instead of dictionaries to ensure the API calls were still successful.

<!--- See how your change affects other areas of the code, etc. -->
Existing functionality that uses the `Dictionary<string, object>` template data should be unaffected as the object used for the template data has not been modified or transformed - this change just broadens the reference type to the object.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
