### PR TITLE
Add optional preheader and AMP fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ var templateSubject = "edited!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>UPDATE</h1></body></html>"; // optional
 updatedTemplateVersion.text = "sometext"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 try
 {
     var templateVersion = await Template.UpdateTemplateVersionAsync(templateId, versionId, updatedTemplateVersion);
@@ -190,6 +191,7 @@ var templateSubject = "edited!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>UPDATE</h1></body></html>"; // optional
 updatedTemplateVersion.text = "sometext"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 try
 {
     var templateVersion = await Template.UpdateTemplateVersionAsync(templateId, versionId, updatedTemplateVersion);
@@ -207,6 +209,7 @@ var templateSubject = "New Version!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>"; // optional
 updatedTemplateVersion.text = "some text"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 updatedTemplateVersion.locale = "en-US"; // optional
 try
 {
@@ -227,6 +230,7 @@ var templateSubject = "Ce est un nouveau modèle!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>Nouveau modèle!</h1></body></html>"; // optional
 updatedTemplateVersion.text = "un texte"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 try
 {
     var template = await Template.AddLocaleToTemplate(templateId, locale, updatedTemplateVersion);
@@ -246,6 +250,7 @@ var templateSubject = "New Version!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>"; // optional
 updatedTemplateVersion.text = "some text"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 try
 {
     var templateVersion = await Template.CreateTemplateVersion(templateId, updatedTemplateVersion);
@@ -265,6 +270,7 @@ var templateSubject = "New Version!";
 var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
 updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>"; // optional
 updatedTemplateVersion.text = "some text"; // optional
+updatedTemplateVersion.preheader = "some preheader"; // optional
 try
 {
     var templateVersion = await Template.CreateTemplateVersion(templateId, locale, updatedTemplateVersion);

--- a/Sendwithus/SendwithusClient/API/Helpers/RenderTemplateResponse.cs
+++ b/Sendwithus/SendwithusClient/API/Helpers/RenderTemplateResponse.cs
@@ -11,6 +11,8 @@ namespace Sendwithus
         public string status { get; set; }
         public RenderTemplateResponseTemplate template { get; set; }
         public string subject { get; set; }
+        public string preheader { get; set; }
+        public string amp_html { get; set; }
         public string html { get; set; }
         public string text { get; set; }
 
@@ -23,6 +25,8 @@ namespace Sendwithus
             status = String.Empty;
             template = new RenderTemplateResponseTemplate();
             subject = String.Empty;
+            preheader = String.Empty;
+            amp_html = String.Empty;
             html = String.Empty;
             text = String.Empty;
         }

--- a/Sendwithus/SendwithusClient/API/Helpers/TemplateVersion.cs
+++ b/Sendwithus/SendwithusClient/API/Helpers/TemplateVersion.cs
@@ -12,9 +12,11 @@ namespace Sendwithus
         public string id { get; set; }
         public string created { get; set; }
         public string modified { get; set; }
+        public string amp_html { get; set; }
         public string html { get; set; }
         public string text { get; set; }
         public string subject { get; set; }
+        public string preheader { get; set; }
         public string locale { get; set; }
         public bool published { get; set; }
 
@@ -31,9 +33,10 @@ namespace Sendwithus
             id = String.Empty;
             created = String.Empty;
             modified = String.Empty;
+            amp_html = String.Empty;
             html = String.Empty;
             text = String.Empty;
-            
+            preheader = String.Empty;
             locale = String.Empty;
             published = false;
         }

--- a/Sendwithus/SendwithusTest/Tests/TemplateTest.cs
+++ b/Sendwithus/SendwithusTest/Tests/TemplateTest.cs
@@ -229,6 +229,9 @@ namespace SendwithusTest
 
                 // Validate the response
                 SendwithusClientTest.ValidateResponse(templateVersion);
+
+                // Check for presence of expected fields
+                Assert.AreEqual(templateVersion.preheader, "A preheader test");
             }
             catch (AggregateException exception)
             {
@@ -251,6 +254,9 @@ namespace SendwithusTest
 
                 // Validate the response
                 SendwithusClientTest.ValidateResponse(templateVersion);
+
+                // Check for presence of expected fields
+                Assert.AreEqual(templateVersion.preheader, "A preheader test");
             }
             catch (AggregateException exception)
             {
@@ -272,6 +278,7 @@ namespace SendwithusTest
             var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
             updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>";
             updatedTemplateVersion.text = "some text";
+            updatedTemplateVersion.preheader = "A Test Preheader";
             try
             { 
                 var templateVersion = await Template.UpdateTemplateVersionAsync(DEFAULT_TEMPLATE_ID, DEFAULT_VERSION_ID, updatedTemplateVersion);
@@ -403,6 +410,7 @@ namespace SendwithusTest
             var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
             updatedTemplateVersion.html = "<html><head></head><body><h1>UPDATE</h1></body></html>";
             updatedTemplateVersion.text = "sometext";
+            updatedTemplateVersion.preheader = "A Test Preheader";
             try
             { 
                 var templateVersion = await Template.UpdateTemplateVersionAsync(DEFAULT_TEMPLATE_ID, DEFAULT_LOCALE, DEFAULT_VERSION_ID, updatedTemplateVersion);
@@ -510,6 +518,7 @@ namespace SendwithusTest
             var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
             updatedTemplateVersion.html = "<html><head></head><body><h1>Nouveau modèle!</h1></body></html>";
             updatedTemplateVersion.text = "un texte";
+            updatedTemplateVersion.preheader = "A French Preheader";
 
             try
             { 
@@ -590,6 +599,7 @@ namespace SendwithusTest
             var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
             updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>";
             updatedTemplateVersion.text = "some text";
+            updatedTemplateVersion.preheader = "A Test Preheader";
             try
             {
                 var templateVersion = await Template.CreateTemplateVersion(DEFAULT_TEMPLATE_ID, updatedTemplateVersion);
@@ -669,6 +679,7 @@ namespace SendwithusTest
             var updatedTemplateVersion = new TemplateVersion(templateVersionName, templateSubject);
             updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>";
             updatedTemplateVersion.text = "some text";
+            updatedTemplateVersion.preheader = "A Test Preheader";
             try
             { 
                 var templateVersion = await Template.CreateTemplateVersion(DEFAULT_TEMPLATE_ID, DEFAULT_LOCALE, updatedTemplateVersion);
@@ -747,6 +758,7 @@ namespace SendwithusTest
             updatedTemplateVersion.html = "<html><head></head><body><h1>NEW TEMPLATE VERSION</h1></body></html>";
             updatedTemplateVersion.text = "some text";
             updatedTemplateVersion.locale = DEFAULT_LOCALE;
+            updatedTemplateVersion.preheader = "Test Preheader";
             return await Template.CreateTemplateAsync(updatedTemplateVersion);
         }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.2.{build}
+version: 2.3.{build}
 
 #---------------------------------#
 #    environment configuration    #


### PR DESCRIPTION
Add support for `preheader` and `amp_html` optional fields for template and render operations

## Description
<!--- Describe your changes in detail if necessary -->
Add `preheader` and `amp_html` to `TemplateVersion` to support create, read and update operations.
Add `preheader` and `amp_html` to `RenderTemplateResponse`.

## Motivation and Context
Parity with the current Sendwithus API
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
* All new and currently passing NUnit tests pass (some unrelated test are currently failing).
* Created a test consumer to verify all affected operations work as expected against test and production environments.
* `amp_html` not yet GA, omitted from test cases.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
