### PR TITLE
Remove response preheader assertions from GetTemplate tests

### DIFF
--- a/Sendwithus/SendwithusTest/Tests/TemplateTest.cs
+++ b/Sendwithus/SendwithusTest/Tests/TemplateTest.cs
@@ -229,9 +229,6 @@ namespace SendwithusTest
 
                 // Validate the response
                 SendwithusClientTest.ValidateResponse(templateVersion);
-
-                // Check for presence of expected fields
-                Assert.AreEqual(templateVersion.preheader, "A preheader test");
             }
             catch (AggregateException exception)
             {
@@ -254,9 +251,6 @@ namespace SendwithusTest
 
                 // Validate the response
                 SendwithusClientTest.ValidateResponse(templateVersion);
-
-                // Check for presence of expected fields
-                Assert.AreEqual(templateVersion.preheader, "A preheader test");
             }
             catch (AggregateException exception)
             {


### PR DESCRIPTION
Revert recent change to check for preheader value in template fetch tests.

## Description
Fetch template operations will continue to test for successful response with validation specific field values.

## Motivation and Context
Results are nondeterministic as the same resources are used in tests for mutation operations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- See how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
